### PR TITLE
Fix: cache compiled config schema

### DIFF
--- a/lib/shared/config-validator.js
+++ b/lib/shared/config-validator.js
@@ -265,7 +265,7 @@ module.exports = class ConfigValidator {
      * @returns {void}
      */
     validateConfigSchema(config, source = null) {
-        validateSchema = this.validateSchema || ajv.compile(configSchema);
+        validateSchema = validateSchema || ajv.compile(configSchema);
 
         if (!validateSchema(config)) {
             throw new Error(`ESLint configuration in ${source} is invalid:\n${this.formatErrors(validateSchema.errors)}`);


### PR DESCRIPTION
Wanted to check again one part of the change from #5, and it turns out it didn't revert behavior regarding the config schema validation from ESLint v7.7.0.

In particular, `ajv.compile` is called every time `validateConfigSchema` is called.

In ESLint v7.7.0 the config schema used to be compiled only once and then cached at the module-level. Here's the original source file:

https://github.com/eslint/eslint/blob/v7.7.0/lib/shared/config-validator.js

This PR fixes the code to cache the compiled schema, as it was working in v7.7.0.

This is probably just a minor performance regression, I'm not sure if this needs another patch release for v7.8.0.