### PR TITLE
Fix: include loadRules in internalSlotsMap cache

### DIFF
--- a/lib/cascading-config-array-factory.js
+++ b/lib/cascading-config-array-factory.js
@@ -256,7 +256,8 @@ class CascadingConfigArrayFactory {
             rulePaths,
             specificConfigPath,
             useEslintrc,
-            builtInRules
+            builtInRules,
+            loadRules
         });
     }
 

--- a/tests/lib/cascading-config-array-factory.js
+++ b/tests/lib/cascading-config-array-factory.js
@@ -1893,4 +1893,22 @@ describe("CascadingConfigArrayFactory", () => {
             });
         });
     });
+
+    describe("bug fixes", () => {
+        /*
+         * Clearing cache would previously error on 'createBaseConfigArray()' call
+         * with 'TypeError: loadRules is not a function'
+         * https://github.com/eslint/eslintrc/pull/19
+         */
+        it("should not error when 'clearCache()' is called with `rulePaths` and 'loadRules' options provided.", () => {
+            const factory = new CascadingConfigArrayFactory({
+                rulePaths: ["./rules"],
+                loadRules() {
+                    return [];
+                },
+            });
+
+            factory.clearCache();
+        });
+    });
 });


### PR DESCRIPTION
This fixes a possible bug that I ran into with `eslint@7.13.0`.  When using the `rulesPath` option of the `ESLint()` constructor it would run into this error

```
TypeError: loadRules is not a function
```

I tracked this down to the implementation of `clearCache()`. When `createBaseConfigArray()` is called it won't supply the `loadRules` property because it doesn't exist in the `internalSlotsMap` value.

https://github.com/eslint/eslintrc/blob/8b202ff866a39efdaad6394fde9f88372afbfca8/lib/cascading-config-array-factory.js#L322-L324

This causes the `loadRules is not a function` on this line:

https://github.com/eslint/eslintrc/blob/8b202ff866a39efdaad6394fde9f88372afbfca8/lib/cascading-config-array-factory.js#L129

Thanks!