### PR TITLE
Update: Implement missing functionality from ESLint port (fixes #12)

### DIFF
--- a/lib/config-array-factory.js
+++ b/lib/config-array-factory.js
@@ -281,14 +281,15 @@ function loadESLintIgnoreFile(filePath) {
  * Creates an error to notify about a missing config to extend from.
  * @param {string} configName The name of the missing config.
  * @param {string} importerName The name of the config that imported the missing config
+ * @param {string} messageTemplate The text template to source error strings from.
  * @returns {Error} The error object to throw
  * @private
  */
-function configMissingError(configName, importerName) {
+function configInvalidError(configName, importerName, messageTemplate) {
     return Object.assign(
         new Error(`Failed to load config "${configName}" to extend from.`),
         {
-            messageTemplate: "extend-config-missing",
+            messageTemplate,
             messageData: { configName, importerName }
         }
     );
@@ -809,7 +810,7 @@ class ConfigArrayFactory {
             });
         }
 
-        throw configMissingError(extendName, ctx.name);
+        throw configInvalidError(extendName, ctx.name, "extend-config-missing");
     }
 
     /**
@@ -821,6 +822,11 @@ class ConfigArrayFactory {
      */
     _loadExtendedPluginConfig(extendName, ctx) {
         const slashIndex = extendName.lastIndexOf("/");
+        
+        if (slashIndex === -1) {
+            throw configInvalidError(extendName, ctx.filePath, "plugin-invalid");
+        }
+        
         const pluginName = extendName.slice("plugin:".length, slashIndex);
         const configName = extendName.slice(slashIndex + 1);
 
@@ -841,7 +847,7 @@ class ConfigArrayFactory {
             });
         }
 
-        throw plugin.error || configMissingError(extendName, ctx.filePath);
+        throw plugin.error || configInvalidError(extendName, ctx.filePath, "extend-config-missing");
     }
 
     /**
@@ -874,7 +880,7 @@ class ConfigArrayFactory {
         } catch (error) {
             /* istanbul ignore else */
             if (error && error.code === "MODULE_NOT_FOUND") {
-                throw configMissingError(extendName, ctx.filePath);
+                throw configInvalidError(extendName, ctx.filePath, "extend-config-missing");
             }
             throw error;
         }

--- a/lib/config-array-factory.js
+++ b/lib/config-array-factory.js
@@ -822,11 +822,11 @@ class ConfigArrayFactory {
      */
     _loadExtendedPluginConfig(extendName, ctx) {
         const slashIndex = extendName.lastIndexOf("/");
-        
+
         if (slashIndex === -1) {
             throw configInvalidError(extendName, ctx.filePath, "plugin-invalid");
         }
-        
+
         const pluginName = extendName.slice("plugin:".length, slashIndex);
         const configName = extendName.slice(slashIndex + 1);
 

--- a/tests/lib/config-array-factory.js
+++ b/tests/lib/config-array-factory.js
@@ -1568,6 +1568,23 @@ describe("ConfigArrayFactory", () => {
             }, /Failed to load config "plugin:invalid-config\/bar" to extend from./u);
         });
 
+        it("should throw an error with a message template when a plugin config specifier is missing config name", () => {
+            try {
+                applyExtends({
+                    extends: "plugin:some-plugin",
+                    rules: { eqeqeq: 2 }
+                });
+            } catch (err) {
+                assert.strictEqual(err.messageTemplate, "plugin-invalid");
+                assert.deepStrictEqual(err.messageData, {
+                    configName: "plugin:some-plugin",
+                    importerName: path.join(getPath(), "whatever")
+                });
+                return;
+            }
+            assert.fail("Expected to throw an error");
+        });
+
         it("should throw an error with a message template when a plugin referenced for a plugin config is not found", () => {
             try {
                 applyExtends({


### PR DESCRIPTION
This implements the missing functionality from ESLint that clearly states the problem when a plugin config is formatted incorrectly.