### PR TITLE
Chore: Replace usage of lodash with cache set

### DIFF
--- a/lib/shared/deprecation-warnings.js
+++ b/lib/shared/deprecation-warnings.js
@@ -9,7 +9,6 @@
 //------------------------------------------------------------------------------
 
 const path = require("path");
-const lodash = require("lodash");
 
 //------------------------------------------------------------------------------
 // Private
@@ -28,6 +27,8 @@ const deprecationWarningMessages = {
         "projects in order to avoid loading '~/.eslintrc.*' accidentally."
 };
 
+const sourceFileErrorCache = new Set();
+
 /**
  * Emits a deprecation warning containing a given filepath. A new deprecation warning is emitted
  * for each unique file path, but repeated invocations with the same file path have no effect.
@@ -36,7 +37,14 @@ const deprecationWarningMessages = {
  * @param {string} errorCode The warning message to show.
  * @returns {void}
  */
-const emitDeprecationWarning = lodash.memoize((source, errorCode) => {
+function emitDeprecationWarning(source, errorCode) {
+    const cacheKey = JSON.stringify({ source, errorCode });
+
+    if (sourceFileErrorCache.has(cacheKey)) {
+        return;
+    }
+    sourceFileErrorCache.add(cacheKey);
+
     const rel = path.relative(process.cwd(), source);
     const message = deprecationWarningMessages[errorCode];
 
@@ -45,7 +53,7 @@ const emitDeprecationWarning = lodash.memoize((source, errorCode) => {
         "DeprecationWarning",
         errorCode
     );
-}, (...args) => JSON.stringify(args));
+}
 
 //------------------------------------------------------------------------------
 // Public Interface

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "ignore": "^4.0.6",
     "import-fresh": "^3.2.1",
     "js-yaml": "^3.13.1",
-    "lodash": "^4.17.20",
     "minimatch": "^3.0.4",
     "strip-json-comments": "^3.1.1"
   },


### PR DESCRIPTION
As part of https://github.com/eslint/eslint/issues/14098, remove
the single usage of `lodash` in this repository with an inlined
version of a cache set. As a result of this change, users of
ESLint will no longer accidentally include a second copy of
lodash in their `node_modules` tree.