### PR TITLE
Update: Fix node_modules pattern

### DIFF
--- a/lib/config-array/ignore-pattern.js
+++ b/lib/config-array/ignore-pattern.js
@@ -109,7 +109,7 @@ function dirSuffix(filePath) {
     return isDir ? "/" : "";
 }
 
-const DefaultPatterns = Object.freeze(["/**/node_modules/*"]);
+const DefaultPatterns = Object.freeze(["node_modules/"]);
 const DotPatterns = Object.freeze([".*", "!.eslintrc.*", "!../"]);
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
ESLint is pointless testing pattern matches of all node_modules sub-directories.  

<details>
  <summary>Logs</summary>

```
...
2021-06-19T02:35:51.904Z eslintrc:ignore-pattern Check {
  filePath: '/home/araujo/Área de trabalho/app-eurora.store/node_modules/.bin/',
  dot: false,
  relativePath: 'node_modules/.bin/',
  result: true
}
2021-06-19T02:35:51.904Z eslint:file-enumerator Didn't match: .modules.yaml
2021-06-19T02:35:51.904Z eslintrc:ignore-pattern Check {
  filePath: '/home/araujo/Área de trabalho/app-eurora.store/node_modules/.pnpm/',
  dot: false,
  relativePath: 'node_modules/.pnpm/',
  result: true
}
2021-06-19T02:35:51.904Z eslint:file-enumerator Didn't match: .pnpm-debug.log
2021-06-19T02:35:51.905Z eslintrc:ignore-pattern Check {
  filePath: '/home/araujo/Área de trabalho/app-eurora.store/node_modules/@babel/',
  dot: false,
  relativePath: 'node_modules/@babel/',
  result: true
}
2021-06-19T02:35:51.905Z eslintrc:ignore-pattern Check {
  filePath: '/home/araujo/Área de trabalho/app-eurora.store/node_modules/@eslint/',
  dot: false,
  relativePath: 'node_modules/@eslint/',
  result: true
}
2021-06-19T02:35:51.905Z eslintrc:ignore-pattern Check {
  filePath: '/home/araujo/Área de trabalho/app-eurora.store/node_modules/@next/',
  dot: false,
  relativePath: 'node_modules/@next/',
  result: true
}
...
2021-06-19T02:40:40.342Z eslintrc:ignore-pattern Check {
  filePath: '/home/araujo/Área de trabalho/app-eurora.store/src/pages/node_modules/',
  dot: false,
  relativePath: 'src/pages/node_modules/',
  result: false
}
...
2021-06-19T02:40:40.343Z eslintrc:ignore-pattern Check {
  filePath: '/home/araujo/Área de trabalho/app-eurora.store/src/pages/node_modules/hello-gui.ts',
  dot: false,
  relativePath: 'src/pages/node_modules/hello-gui.ts',
  result: true
}
```
</details>

according to docs ignore patterns behave according to the .gitignore specification, so `node_modules/` is the correct pattern for full matching all node_modules directories.  

<details>
  <summary>Logs after</summary>

```
2021-06-19T02:41:24.724Z eslintrc:ignore-pattern Check {
  filePath: '/home/araujo/Área de trabalho/app-eurora.store/node_modules/',
  dot: false,
  relativePath: 'node_modules/',
  result: true
}
...
2021-06-19T02:41:24.741Z eslintrc:ignore-pattern Check {
  filePath: '/home/araujo/Área de trabalho/app-eurora.store/src/pages/node_modules/',
  dot: false,
  relativePath: 'src/pages/node_modules/',
  result: true
}
```
</details>
