### PR TITLE
Fix: ensure config files are files

### DIFF
--- a/lib/config-array-factory.js
+++ b/lib/config-array-factory.js
@@ -495,7 +495,7 @@ class ConfigArrayFactory {
                 basePath
             );
 
-            if (fs.existsSync(ctx.filePath)) {
+            if (fs.existsSync(ctx.filePath) && fs.statSync(ctx.filePath).isFile()) {
                 let configData;
 
                 try {

--- a/tests/lib/config-array-factory.js
+++ b/tests/lib/config-array-factory.js
@@ -269,7 +269,8 @@ describe("ConfigArrayFactory", () => {
             files: {
                 ...basicFiles,
                 "invalid-property/.eslintrc.json": "{ \"files\": \"*.js\" }",
-                "package-json-no-config/package.json": "{ \"name\": \"foo\" }"
+                "package-json-no-config/package.json": "{ \"name\": \"foo\" }",
+                "package-json-dir/package.json/something": "{}"
             }
         });
 
@@ -299,6 +300,12 @@ describe("ConfigArrayFactory", () => {
             assert.throws(() => {
                 factory.loadInDirectory("invalid-property");
             }, /Unexpected top-level property "files"/u);
+        });
+
+        it("should ignore directories that have the same name as a config file,", () => {
+            const configArray = factory.loadInDirectory("package-json-dir");
+
+            assert.strictEqual(configArray.length, 0);
         });
 
         for (const filePath of Object.keys(basicFiles)) {


### PR DESCRIPTION
Currently if a directory name matches a config file it will be treated as a file and then fail later when we try and read it.

This is causing an error for us in a fixture where we have a directory called "package.json".

Refs https://github.com/rollup/plugins/pull/927