### PR TITLE
Update: Add /universal entrypoint (fixes #50)

### DIFF
--- a/lib/index-universal.js
+++ b/lib/index-universal.js
@@ -1,0 +1,29 @@
+/**
+ * @fileoverview Package exports for @eslint/eslintrc
+ * @author Nicholas C. Zakas
+ */
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+import * as ConfigOps from "./shared/config-ops.js";
+import ConfigValidator from "./shared/config-validator.js";
+import * as naming from "./shared/naming.js";
+import environments from "../conf/environments.js";
+
+//-----------------------------------------------------------------------------
+// Exports
+//-----------------------------------------------------------------------------
+
+const Legacy = {
+    environments,
+
+    // shared
+    ConfigOps,
+    ConfigValidator,
+    naming
+};
+
+export {
+    Legacy
+};

--- a/lib/shared/ajv.js
+++ b/lib/shared/ajv.js
@@ -9,10 +9,164 @@
 
 import Ajv from "ajv";
 
-import { createRequire } from "module";
-const require = createRequire(import.meta.url);
+//-----------------------------------------------------------------------------
+// Helpers
+//-----------------------------------------------------------------------------
 
-const metaSchema = require("ajv/lib/refs/json-schema-draft-04.json");
+/*
+ * Copied from ajv/lib/refs/json-schema-draft-04.json
+ * The MIT License (MIT)
+ * Copyright (c) 2015-2017 Evgeny Poberezkin
+ */
+const metaSchema = {
+    id: "http://json-schema.org/draft-04/schema#",
+    $schema: "http://json-schema.org/draft-04/schema#",
+    description: "Core schema meta-schema",
+    definitions: {
+        schemaArray: {
+            type: "array",
+            minItems: 1,
+            items: { $ref: "#" }
+        },
+        positiveInteger: {
+            type: "integer",
+            minimum: 0
+        },
+        positiveIntegerDefault0: {
+            allOf: [{ $ref: "#/definitions/positiveInteger" }, { default: 0 }]
+        },
+        simpleTypes: {
+            enum: ["array", "boolean", "integer", "null", "number", "object", "string"]
+        },
+        stringArray: {
+            type: "array",
+            items: { type: "string" },
+            minItems: 1,
+            uniqueItems: true
+        }
+    },
+    type: "object",
+    properties: {
+        id: {
+            type: "string"
+        },
+        $schema: {
+            type: "string"
+        },
+        title: {
+            type: "string"
+        },
+        description: {
+            type: "string"
+        },
+        default: { },
+        multipleOf: {
+            type: "number",
+            minimum: 0,
+            exclusiveMinimum: true
+        },
+        maximum: {
+            type: "number"
+        },
+        exclusiveMaximum: {
+            type: "boolean",
+            default: false
+        },
+        minimum: {
+            type: "number"
+        },
+        exclusiveMinimum: {
+            type: "boolean",
+            default: false
+        },
+        maxLength: { $ref: "#/definitions/positiveInteger" },
+        minLength: { $ref: "#/definitions/positiveIntegerDefault0" },
+        pattern: {
+            type: "string",
+            format: "regex"
+        },
+        additionalItems: {
+            anyOf: [
+                { type: "boolean" },
+                { $ref: "#" }
+            ],
+            default: { }
+        },
+        items: {
+            anyOf: [
+                { $ref: "#" },
+                { $ref: "#/definitions/schemaArray" }
+            ],
+            default: { }
+        },
+        maxItems: { $ref: "#/definitions/positiveInteger" },
+        minItems: { $ref: "#/definitions/positiveIntegerDefault0" },
+        uniqueItems: {
+            type: "boolean",
+            default: false
+        },
+        maxProperties: { $ref: "#/definitions/positiveInteger" },
+        minProperties: { $ref: "#/definitions/positiveIntegerDefault0" },
+        required: { $ref: "#/definitions/stringArray" },
+        additionalProperties: {
+            anyOf: [
+                { type: "boolean" },
+                { $ref: "#" }
+            ],
+            default: { }
+        },
+        definitions: {
+            type: "object",
+            additionalProperties: { $ref: "#" },
+            default: { }
+        },
+        properties: {
+            type: "object",
+            additionalProperties: { $ref: "#" },
+            default: { }
+        },
+        patternProperties: {
+            type: "object",
+            additionalProperties: { $ref: "#" },
+            default: { }
+        },
+        dependencies: {
+            type: "object",
+            additionalProperties: {
+                anyOf: [
+                    { $ref: "#" },
+                    { $ref: "#/definitions/stringArray" }
+                ]
+            }
+        },
+        enum: {
+            type: "array",
+            minItems: 1,
+            uniqueItems: true
+        },
+        type: {
+            anyOf: [
+                { $ref: "#/definitions/simpleTypes" },
+                {
+                    type: "array",
+                    items: { $ref: "#/definitions/simpleTypes" },
+                    minItems: 1,
+                    uniqueItems: true
+                }
+            ]
+        },
+        format: { type: "string" },
+        allOf: { $ref: "#/definitions/schemaArray" },
+        anyOf: { $ref: "#/definitions/schemaArray" },
+        oneOf: { $ref: "#/definitions/schemaArray" },
+        not: { $ref: "#" }
+    },
+    dependencies: {
+        exclusiveMaximum: ["maximum"],
+        exclusiveMinimum: ["minimum"]
+    },
+    default: { }
+};
 
 //------------------------------------------------------------------------------
 // Public Interface

--- a/package.json
+++ b/package.json
@@ -9,13 +9,17 @@
       "import": "./lib/index.js",
       "require": "./dist/eslintrc.cjs"
     },
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./universal": {
+      "import": "./lib/index-universal.js",
+      "require": "./dist/eslintrc-universal.cjs"
+    }
   },
   "files": [
     "lib",
     "conf",
     "LICENSE",
-    "dist/eslintrc.cjs"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,14 +1,30 @@
-export default {
-    input: "./lib/index.js",
-    external: [
-        "module", "util", "os", "path", "debug", "fs", "import-fresh",
-        "strip-json-comments", "assert", "ignore", "minimatch", "url", "ajv",
-        "globals"
-    ],
-    treeshake: false,
-    output: {
-        format: "cjs",
-        file: "dist/eslintrc.cjs",
-        sourcemap: true
+export default [
+    {
+        input: "./lib/index.js",
+        external: [
+            "module", "util", "os", "path", "debug", "fs", "import-fresh",
+            "strip-json-comments", "assert", "ignore", "minimatch", "url", "ajv",
+            "globals"
+        ],
+        treeshake: false,
+        output: {
+            format: "cjs",
+            file: "dist/eslintrc.cjs",
+            sourcemap: true
+        }
+    },
+    {
+        input: "./lib/index-universal.js",
+        external: [
+            "module", "util", "os", "path", "debug", "fs", "import-fresh",
+            "strip-json-comments", "assert", "ignore", "minimatch", "url", "ajv",
+            "globals"
+        ],
+        treeshake: false,
+        output: {
+            format: "cjs",
+            file: "dist/eslintrc-universal.cjs",
+            sourcemap: true
+        }
     }
-};
+];

--- a/tests/lib/commonjs.cjs
+++ b/tests/lib/commonjs.cjs
@@ -11,13 +11,14 @@
 
 const assert = require("assert");
 const eslintrc = require("../../dist/eslintrc.cjs");
+const universal = require("../../dist/eslintrc-universal.cjs");
 
 
 //------------------------------------------------------------------------------
 // Tests
 //------------------------------------------------------------------------------
 
-describe("commonjs", () => {
+describe("eslintrc CommonJS", () => {
     it("is an object", () => {
         assert.strictEqual(typeof eslintrc, "object");
     });
@@ -25,7 +26,6 @@ describe("commonjs", () => {
     it("has exports", () => {
         assert.strictEqual(typeof eslintrc.FlatCompat, "function");
         assert.strictEqual(typeof eslintrc.Legacy, "object");
-        assert.strictEqual(typeof eslintrc.Legacy.environments, "object");
 
         [
             "ConfigArray",
@@ -44,8 +44,29 @@ describe("commonjs", () => {
 
         // shared
         [
+            "environments",
             "ConfigOps",
             "ModuleResolver",
+            "naming"
+        ].forEach(prop => {
+            assert.strictEqual(typeof eslintrc.Legacy[prop], "object");
+        });
+    });
+});
+
+describe("eslintrc CommonJS Universal", () => {
+    it("is an object", () => {
+        assert.strictEqual(typeof eslintrc, "object");
+    });
+
+    it("has exports", () => {
+        assert.strictEqual(typeof eslintrc.Legacy, "object");
+        assert.strictEqual(typeof eslintrc.Legacy.ConfigValidator, "function");
+
+        // shared
+        [
+            "environments",
+            "ConfigOps",
             "naming"
         ].forEach(prop => {
             assert.strictEqual(typeof eslintrc.Legacy[prop], "object");

--- a/tests/lib/commonjs.cjs
+++ b/tests/lib/commonjs.cjs
@@ -56,12 +56,12 @@ describe("eslintrc CommonJS", () => {
 
 describe("eslintrc CommonJS Universal", () => {
     it("is an object", () => {
-        assert.strictEqual(typeof eslintrc, "object");
+        assert.strictEqual(typeof universal, "object");
     });
 
     it("has exports", () => {
-        assert.strictEqual(typeof eslintrc.Legacy, "object");
-        assert.strictEqual(typeof eslintrc.Legacy.ConfigValidator, "function");
+        assert.strictEqual(typeof universal.Legacy, "object");
+        assert.strictEqual(typeof universal.Legacy.ConfigValidator, "function");
 
         // shared
         [
@@ -69,7 +69,7 @@ describe("eslintrc CommonJS Universal", () => {
             "ConfigOps",
             "naming"
         ].forEach(prop => {
-            assert.strictEqual(typeof eslintrc.Legacy[prop], "object");
+            assert.strictEqual(typeof universal.Legacy[prop], "object");
         });
     });
 });


### PR DESCRIPTION
Adds a new `/universal` entrypoint that exports only members that are browser-safe. Once this is merged, we should change [this line in linter.js](https://github.com/eslint/eslint/blob/master/lib/linter/linter.js#L19-L23) from:

```js
    const {
        Legacy: {
            ConfigOps,
            ConfigValidator,
            environments: BuiltInEnvironments
        }
    } = require("@eslint/eslintrc"),

```

to

```js
const    {
        Legacy: {
            ConfigOps,
            ConfigValidator,
            environments: BuiltInEnvironments
        }
    } = require("@eslint/eslintrc/universal"),
```
