### PR TITLE
Fix: ConfigArrayFactory was ignoring the resolver option in some places

### DIFF
--- a/lib/config-array-factory.js
+++ b/lib/config-array-factory.js
@@ -926,11 +926,11 @@ class ConfigArrayFactory {
     _loadParser(nameOrPath, ctx) {
         debug("Loading parser %j from %s", nameOrPath, ctx.filePath);
 
-        const { cwd } = internalSlotsMap.get(this);
+        const { cwd, resolver } = internalSlotsMap.get(this);
         const relativeTo = ctx.filePath || path.join(cwd, "__placeholder__.js");
 
         try {
-            const filePath = ModuleResolver.resolve(nameOrPath, relativeTo);
+            const filePath = resolver.resolve(nameOrPath, relativeTo);
 
             writeDebugLogForLoading(nameOrPath, relativeTo, filePath);
 
@@ -977,7 +977,7 @@ class ConfigArrayFactory {
     _loadPlugin(name, ctx) {
         debug("Loading plugin %j from %s", name, ctx.filePath);
 
-        const { additionalPluginPool } = internalSlotsMap.get(this);
+        const { additionalPluginPool, resolver } = internalSlotsMap.get(this);
         const request = naming.normalizePackageName(name, "eslint-plugin");
         const id = naming.getShorthandName(request, "eslint-plugin");
         const relativeTo = path.join(ctx.pluginBasePath, "__placeholder__.js");
@@ -1018,7 +1018,7 @@ class ConfigArrayFactory {
         let error;
 
         try {
-            filePath = ModuleResolver.resolve(request, relativeTo);
+            filePath = resolver.resolve(request, relativeTo);
         } catch (resolveError) {
             error = resolveError;
             /* istanbul ignore else */


### PR DESCRIPTION
Hi,

I was experimenting with ESLint 8 Beta and wanted to create a pull-request, but saw that there was an issue when using the `resolver` option on `ConfigArrayFactory` as it was ignored in some functions.

This PR uses the `resolver` in the slot instead of `ModuleResolver.resolve`