### PR TITLE
Chore: ignore package manager lock files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,8 @@ dist
 
 # TernJS port file
 .tern-port
+
+# lock files
+yarn.lock
+package-lock.json
+pnpm-lock.yaml


### PR DESCRIPTION
This repo doesn't use one and other repositories in the organization also ignore these files.

https://github.com/eslint/eslint/blob/2d654f115f6e05b59c85434e75cf68204b976f22/.gitignore#L26
