### PR TITLE
fix: add `universal` export to root

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "conf",
     "LICENSE",
     "dist"
+    "universal.js"
   ],
   "publishConfig": {
     "access": "public"

--- a/universal.js
+++ b/universal.js
@@ -1,0 +1,1 @@
+module.exports = require("./dist/eslintrc-universal.cjs");


### PR DESCRIPTION
Jest doesn't support package exports ([yet](https://github.com/facebook/jest/issues/9771)), so if you currently try to load `eslint` from within Jest (such as for running `ruleTester`) it fails to resolve unless the user adds some config like

```json
{
  "jest": {
    "moduleNameMapper": {
      "@eslint/eslintrc/universal": "@eslint/eslintrc/dist/eslintrc-universal.cjs"
    }
  }
}
```

It would be nice if it just worked 🙂 

I very much understand if you don't wanna add this hack for Jest's lack of support for package exports, but since it's not a big burden I have some hope 👍 