### PR TITLE
chore: update `js-yaml` dependency

### DIFF
--- a/lib/config-array-factory.js
+++ b/lib/config-array-factory.js
@@ -162,7 +162,7 @@ function loadYAMLConfigFile(filePath) {
     try {
 
         // empty YAML file can be null, so always use
-        return yaml.safeLoad(readFile(filePath)) || {};
+        return yaml.load(readFile(filePath)) || {};
     } catch (e) {
         debug(`Error reading YAML file: ${filePath}`);
         e.message = `Cannot read config file: ${filePath}\nError: ${e.message}`;
@@ -208,7 +208,7 @@ function loadLegacyConfigFile(filePath) {
     const yaml = require("js-yaml");
 
     try {
-        return yaml.safeLoad(stripComments(readFile(filePath))) || /* istanbul ignore next */ {};
+        return yaml.load(stripComments(readFile(filePath))) || /* istanbul ignore next */ {};
     } catch (e) {
         debug("Error reading YAML file: %s\n%o", filePath, e);
         e.message = `Cannot read config file: ${filePath}\nError: ${e.message}`;

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "globals": "^13.9.0",
     "ignore": "^4.0.6",
     "import-fresh": "^3.2.1",
-    "js-yaml": "^3.13.1",
+    "js-yaml": "^4.1.0",
     "minimatch": "^3.0.4",
     "strip-json-comments": "^3.1.1"
   },


### PR DESCRIPTION
Follow up https://github.com/eslint/eslintrc/pull/60

Fix https://github.com/eslint/eslintrc/issues/59

See https://github.com/nodeca/js-yaml/blob/49baadd52af887d2991e2c39a6639baa56d6c71b/migrate_v3_to_v4.md#safeload-safeloadall-safedump--load-loadall-dump