### PR TITLE
build: upgrade eslint-release to v3.2.0 to support conventional commits

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "eslint-config-eslint": "^7.0.0",
     "eslint-plugin-jsdoc": "^35.4.1",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-release": "^3.1.2",
+    "eslint-release": "^3.2.0",
     "fs-teardown": "^0.1.3",
     "mocha": "^9.0.3",
     "rollup": "^2.54.0",


### PR DESCRIPTION
Updates eslint-release dependency to the latest v3.2.0, which supports conventional commits.