### PR TITLE
chore: upgrade espree@9.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   "dependencies": {
     "ajv": "^6.12.4",
     "debug": "^4.3.2",
-    "espree": "^9.2.0",
+    "espree": "^9.3.0",
     "globals": "^13.9.0",
     "ignore": "^4.0.6",
     "import-fresh": "^3.2.1",


### PR DESCRIPTION
Noticed that this was still 9.2.0. This is loaded as a default instead of 9.3.0.