### PR TITLE
chore: update ignore to match the version in main eslint package

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "debug": "^4.3.2",
     "espree": "^9.3.0",
     "globals": "^13.9.0",
-    "ignore": "^4.0.6",
+    "ignore": "^5.2.0",
     "import-fresh": "^3.2.1",
     "js-yaml": "^4.1.0",
     "minimatch": "^3.0.4",


### PR DESCRIPTION
Allow deduplicating the ignore package when installing eslint.

ignore 5 supports Node.js > 6 and was release in 2018.
The main breaking change seems to be
that it throws an exception on invalid path names.

eslint currently depends on ignore ^5.2.0

ignore changelog: https://github.com/kaelzhang/node-ignore/releases