### PR TITLE
chore: upgrade `ignore` to `v5.2.0`

### DIFF
--- a/lib/config-array/ignore-pattern.js
+++ b/lib/config-array/ignore-pattern.js
@@ -156,8 +156,8 @@ class IgnorePattern {
         const patterns = [].concat(
             ...ignorePatterns.map(p => p.getPatternsRelativeTo(basePath))
         );
-        const ig = ignore().add([...DotPatterns, ...patterns]);
-        const dotIg = ignore().add(patterns);
+        const ig = ignore({ allowRelativePaths: true }).add([...DotPatterns, ...patterns]);
+        const dotIg = ignore({ allowRelativePaths: true }).add(patterns);
 
         debug("  processed: %o", { basePath, patterns });
 

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "debug": "^4.3.2",
     "espree": "^9.3.1",
     "globals": "^13.9.0",
-    "ignore": "^4.0.6",
+    "ignore": "^5.2.0",
     "import-fresh": "^3.2.1",
     "js-yaml": "^4.1.0",
     "minimatch": "^3.0.4",


### PR DESCRIPTION
Fix https://github.com/eslint/eslint/issues/15642

Upgrade `ignore` to `v5.2.0`. Use `{ allowRelativePaths: true }` to get the v4 behavior.