### PR TITLE
fix: use custom Rollup plugin for `import.meta.url`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ dist
 yarn.lock
 package-lock.json
 pnpm-lock.yaml
+
+# used in tests
+/tmp/

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "eslint-release": "^3.2.0",
     "fs-teardown": "^0.1.3",
     "mocha": "^9.0.3",
-    "rollup": "^2.54.0",
+    "rollup": "^2.70.1",
     "shelljs": "^0.8.4",
     "sinon": "^11.1.2",
     "temp-dir": "^2.0.0"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,3 +1,22 @@
+/**
+ * Custom Rollup plugin for `import.meta.url` transformation to commonjs.
+ * The default transformation ('file:' + __filename) does not check characters in __filename,
+ * and thus can produce invalid URLs, like in https://github.com/eslint/eslint/issues/15766
+ * See https://github.com/eslint/eslint/issues/15766#issuecomment-1093941321
+ * @returns {Object} Rollup plugin object.
+ */
+function importMetaURLPlugin() {
+    return {
+        name: "custom-import-meta-url",
+        resolveImportMeta(property) {
+            if (property === "url") {
+                return "require('url').pathToFileURL(__filename)";
+            }
+            return null;
+        }
+    };
+}
+
 export default [
     {
         input: "./lib/index.js",
@@ -12,7 +31,8 @@ export default [
             file: "dist/eslintrc.cjs",
             sourcemap: true,
             freeze: false
-        }
+        },
+        plugins: [importMetaURLPlugin()]
     },
     {
         input: "./lib/index-universal.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,7 +10,7 @@ function importMetaURLPlugin() {
         name: "custom-import-meta-url",
         resolveImportMeta(property) {
             if (property === "url") {
-                return "require('url').pathToFileURL(__filename)";
+                return "require('url').pathToFileURL(__filename).toString()";
             }
             return null;
         }

--- a/tests/lib/commonjs.cjs
+++ b/tests/lib/commonjs.cjs
@@ -12,7 +12,8 @@
 const assert = require("assert");
 const eslintrc = require("../../dist/eslintrc.cjs");
 const universal = require("../../dist/eslintrc-universal.cjs");
-
+const path = require("path");
+const sh = require("shelljs");
 
 //------------------------------------------------------------------------------
 // Tests
@@ -71,5 +72,23 @@ describe("eslintrc CommonJS Universal", () => {
         ].forEach(prop => {
             assert.strictEqual(typeof universal.Legacy[prop], "object");
         });
+    });
+});
+
+// https://github.com/eslint/eslint/issues/15766
+describe("eslintrc CommonJS loading", () => {
+    const testDir = path.resolve(__dirname, "../../tmp/my%2Fproject");
+
+    before(() => {
+        sh.mkdir("-p", testDir);
+        sh.cp("", "./dist/eslintrc.cjs", testDir);
+    });
+
+    after(() => {
+        sh.rm("-r", testDir);
+    });
+
+    it("eslintrc.cjs module successfully loads when it is in a path that contains URL-encoded characters", () => {
+        require(path.resolve(testDir, "eslintrc.cjs"));
     });
 });


### PR DESCRIPTION
Refs eslint/eslint#15766, this should fix the issue.

`dist/eslintrc.cjs` diff (line 2383):

```diff
- const require$1 = Module.createRequire((typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __filename).href : (document.currentScript && document.currentScript.src || new URL('eslintrc.cjs', document.baseURI).href)));
+ const require$1 = Module.createRequire(require('url').pathToFileURL(__filename).toString());
```

The new version does not include code for browsers (`typeof document ...`), I'm not sure why Rollup's default transformation includes it when the output format is set to `"cjs"`.

Without this change, the added test case fails with the same error as in eslint/eslint#15766.

