### PR TITLE
feat: allow loading shareable configs with cli `--config` option

### DIFF
--- a/lib/config-array-factory.js
+++ b/lib/config-array-factory.js
@@ -485,7 +485,18 @@ class ConfigArrayFactory {
         const slots = internalSlotsMap.get(this);
         const ctx = createContext(slots, "config", name, filePath, basePath);
 
-        return new ConfigArray(...this._loadConfigData(ctx));
+        let configArray;
+
+        try {
+            configArray = new ConfigArray(...this._loadConfigData(ctx));
+        } catch (error) {
+            if (error.messageTemplate === "failed-to-read-json") {
+                configArray = new ConfigArray(...this._loadExtendedShareableConfig(filePath, ctx));
+            } else {
+                throw error;
+            }
+        }
+        return configArray;
     }
 
     /**

--- a/tests/lib/config-array-factory.js
+++ b/tests/lib/config-array-factory.js
@@ -2681,10 +2681,10 @@ describe("ConfigArrayFactory", () => {
                 try {
                     load(factory, "broken-package-json/package.json");
                 } catch (error) {
-                    assert.strictEqual(error.messageTemplate, "failed-to-read-json");
+                    assert.strictEqual(error.messageTemplate, "extend-config-missing");
                     throw error;
                 }
-            }, /Cannot read config file/u);
+            }, /Failed to load config "broken-package-json\/package.json" to extend from./u);
         });
 
         it("should load fresh information from a package.json file", () => {


### PR DESCRIPTION
Hello! 

Currently, when you are trying to pass a package name in a `--config` CLI option you always get a  _"Oops! Something went wrong! :("_ error. This is because loading modules via CLI is apparently not supported:

```sh
eslint -c @scope/eslint-config .

Oops! Something went wrong! :(

ESLint: 7.32.0

Error: Cannot read config file: /project/@scope/eslint-config
Error: ENOENT: no such file or directory, open '/project/@scope/eslint-config'
```

In the suggested patch I've added a way to try loading a **shareable config** whenever loading config **file** fails. Please let me know what you think of this, or is there maybe another way I should go about implementing this.