### PR TITLE
chore: Upgrade to espree@9.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "dependencies": {
     "ajv": "^6.12.4",
     "debug": "^4.3.2",
-    "espree": "^9.3.2",
+    "espree": "^9.4.0",
     "globals": "^13.15.0",
     "ignore": "^5.2.0",
     "import-fresh": "^3.2.1",


### PR DESCRIPTION
Updates espree dependency to sync with the eslint package.