### PR TITLE
feat: add version to ConfigDependency

### DIFF
--- a/lib/config-array-factory.js
+++ b/lib/config-array-factory.js
@@ -306,7 +306,7 @@ function configInvalidError(configName, importerName, messageTemplate) {
 
 /**
  * Loads a configuration file regardless of the source. Inspects the file path
- * to determine the correctly way to load the config file.
+ * to determine the correct way to load the config file.
  * @param {string} filePath The path to the configuration.
  * @returns {ConfigData|null} The configuration information.
  * @private
@@ -333,6 +333,27 @@ function loadConfigFile(filePath) {
 }
 
 /**
+ * Returns the version of a module
+ * @param {string} request The requested module name.
+ * @param {string} relativeTo The file path to resolve the request relative to.
+ * @returns {string | null} The version of the requested module.
+ */
+function getVersion(request, relativeTo) {
+    try {
+        const packageJsonPath = ModuleResolver.resolve(
+            `${request}/package.json`,
+            relativeTo
+        );
+        const { version } = require(packageJsonPath);
+
+        return version;
+    } catch (error) {
+        debug(`package.json for ${request} was not found:`, error.message);
+    }
+    return null;
+}
+
+/**
  * Write debug log.
  * @param {string} request The requested module name.
  * @param {string} relativeTo The file path to resolve the request relative to.
@@ -342,20 +363,8 @@ function loadConfigFile(filePath) {
 function writeDebugLogForLoading(request, relativeTo, filePath) {
     /* istanbul ignore next */
     if (debug.enabled) {
-        let nameAndVersion = null;
-
-        try {
-            const packageJsonPath = ModuleResolver.resolve(
-                `${request}/package.json`,
-                relativeTo
-            );
-            const { version = "unknown" } = require(packageJsonPath);
-
-            nameAndVersion = `${request}@${version}`;
-        } catch (error) {
-            debug("package.json was not found:", error.message);
-            nameAndVersion = request;
-        }
+        const version = getVersion(request, relativeTo);
+        const nameAndVersion = version ? `${request}@${version}` : request;
 
         debug("Loaded: %s (%s)", nameAndVersion, filePath);
     }
@@ -963,10 +972,12 @@ class ConfigArrayFactory {
             const filePath = resolver.resolve(nameOrPath, relativeTo);
 
             writeDebugLogForLoading(nameOrPath, relativeTo, filePath);
+            const version = getVersion(nameOrPath, relativeTo);
 
             return new ConfigDependency({
                 definition: require(filePath),
                 filePath,
+                version,
                 id: nameOrPath,
                 importerName: ctx.name,
                 importerPath: ctx.filePath
@@ -1065,6 +1076,7 @@ class ConfigArrayFactory {
         if (filePath) {
             try {
                 writeDebugLogForLoading(request, relativeTo, filePath);
+                const version = getVersion(request, relativeTo);
 
                 const startTime = Date.now();
                 const pluginDefinition = require(filePath);
@@ -1073,6 +1085,7 @@ class ConfigArrayFactory {
 
                 return new ConfigDependency({
                     definition: normalizePlugin(pluginDefinition),
+                    version,
                     filePath,
                     id,
                     importerName: ctx.name,

--- a/lib/config-array/config-dependency.js
+++ b/lib/config-array/config-dependency.js
@@ -30,6 +30,7 @@ class ConfigDependency {
      * @param {T} [data.definition] The dependency if the loading succeeded.
      * @param {Error} [data.error] The error object if the loading failed.
      * @param {string} [data.filePath] The actual path to the dependency if the loading succeeded.
+     * @param {string} [data.version] The version of this dependency.
      * @param {string} data.id The ID of this dependency.
      * @param {string} data.importerName The name of the config file which loads this dependency.
      * @param {string} data.importerPath The path to the config file which loads this dependency.
@@ -39,6 +40,7 @@ class ConfigDependency {
         error = null,
         filePath = null,
         id,
+        version = null,
         importerName,
         importerPath
     }) {
@@ -48,6 +50,12 @@ class ConfigDependency {
          * @type {T|null}
          */
         this.definition = definition;
+
+        /**
+         * The version of this dependency.
+         * @type {string|null}
+         */
+        this.version = version;
 
         /**
          * The error object if the loading failed.

--- a/tests/lib/config-array/config-dependency.js
+++ b/tests/lib/config-array/config-dependency.js
@@ -66,6 +66,7 @@ describe("ConfigDependency", () => {
                 {
                     error: { message: "error?" },
                     filePath: "filePath?",
+                    version: null,
                     id: "id?",
                     importerName: "importerName?",
                     importerPath: "importerPath?"
@@ -90,6 +91,7 @@ describe("ConfigDependency", () => {
             const error = new Error("error?"); // reuse error object to use the same stacktrace.
             const dep = new ConfigDependency({
                 definition: { name: "definition?" },
+                version: "1.0.1",
                 error,
                 filePath: "filePath?",
                 id: "id?",
@@ -105,6 +107,7 @@ describe("ConfigDependency", () => {
             // Make expected output; no `definition` property.
             output = "";
             localConsole.log({
+                version: "1.0.1",
                 error,
                 filePath: "filePath?",
                 id: "id?",


### PR DESCRIPTION
The goal of this additional key is that the version of additional dependencies, in particular plugins or config repos, be included within the final config hash of eslint.
With this behavior, cache busting should happen automatically when one of the dependency versions changes.

I ran in this situation recently after upgrading eslint-plugin-react, and developers seeing different results of eslint on different machines and the CI.

I'd expect this change to seemlessly trigger cache-busting within eslint itself when updating dependencies.