### PR TITLE
chore: cascading-config-array: createBaseConfigArray call: rm useless argument `resolver`

### DIFF
--- a/lib/cascading-config-array-factory.js
+++ b/lib/cascading-config-array-factory.js
@@ -250,8 +250,7 @@ class CascadingConfigArrayFactory {
                 configArrayFactory,
                 cwd,
                 rulePaths,
-                loadRules,
-                resolver
+                loadRules
             }),
             baseConfigData,
             cliConfigArray: createCLIConfigArray({


### PR DESCRIPTION
Function `createBaseConfigArray` didn't expect `resolver` property in arguments. 