### PR TITLE
fix: Update FlatCompat docs + typings to reflect Array

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,19 +37,19 @@ const compat = new FlatCompat({
 export default [
 
     // mimic ESLintRC-style extends
-    compat.extends("standard", "example"),
+    ...compat.extends("standard", "example"),
 
     // mimic environments
-    compat.env({
+    ...compat.env({
         es2020: true,
         node: true
     }),
 
     // mimic plugins
-    compat.plugins("airbnb", "react"),
+    ...compat.plugins("airbnb", "react"),
 
     // translate an entire config
-    compat.config({
+    ...compat.config({
         plugins: ["airbnb", "react"],
         extends: "standard",
         env: {

--- a/lib/flat-compat.js
+++ b/lib/flat-compat.js
@@ -273,7 +273,7 @@ class FlatCompat {
     /**
      * Translates the `env` section of an ESLintRC-style config.
      * @param {Object} envConfig The `env` section of an ESLintRC config.
-     * @returns {Object} A flag-config object representing the environments.
+     * @returns {Object[]} An array of flag-config objects representing the environments.
      */
     env(envConfig) {
         return this.config({
@@ -284,7 +284,7 @@ class FlatCompat {
     /**
      * Translates the `extends` section of an ESLintRC-style config.
      * @param {...string} configsToExtend The names of the configs to load.
-     * @returns {Object} A flag-config object representing the config.
+     * @returns {Object[]} An array of flag-config objects representing the config.
      */
     extends(...configsToExtend) {
         return this.config({
@@ -295,7 +295,7 @@ class FlatCompat {
     /**
      * Translates the `plugins` section of an ESLintRC-style config.
      * @param {...string} plugins The names of the plugins to load.
-     * @returns {Object} A flag-config object representing the plugins.
+     * @returns {Object[]} An array of flag-config objects representing the plugins.
      */
     plugins(...plugins) {
         return this.config({


### PR DESCRIPTION
I know this repo is frozen, but I'm just trying out 1.4 and all the compat methods give me an array, passing them into the `export default []` as shown in the docs gives "Unexpected Array" Error. 

Perhaps there is just a missing .flat() on the end of the config instead of having to spread into the config array? 