### PR TITLE
feat!: Require eslint:all and eslint:recommended as parameters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The primary class in this package is `FlatCompat`, which is a utility to transla
 
 ```js
 import { FlatCompat } from "@eslint/eslintrc";
+import js from "@eslint/js";
 import path from "path";
 import { fileURLToPath } from "url";
 
@@ -30,8 +31,10 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const compat = new FlatCompat({
-    baseDirectory: __dirname,                // optional; default: process.cwd()
-    resolvePluginsRelativeTo: __dirname      // optional
+    baseDirectory: __dirname,                  // optional; default: process.cwd()
+    resolvePluginsRelativeTo: __dirname,       // optional
+    recommendedConfig: js.configs.recommended, // optional
+    allConfig: js.configs.all,                 // optional
 });
 
 export default [

--- a/lib/flat-compat.js
+++ b/lib/flat-compat.js
@@ -53,17 +53,6 @@ function translateESLintRC(eslintrcConfig, {
     const languageOptionsKeysToCopy = ["globals", "parser", "parserOptions"];
     const linterOptionsKeysToCopy = ["noInlineConfig", "reportUnusedDisableDirectives"];
 
-    // check for special settings for eslint:all and eslint:recommended:
-    if (eslintrcConfig.settings) {
-        if (eslintrcConfig.settings["eslint:all"] === true) {
-            return ["eslint:all"];
-        }
-
-        if (eslintrcConfig.settings["eslint:recommended"] === true) {
-            return ["eslint:recommended"];
-        }
-    }
-
     // copy over simple translations
     for (const key of keysToCopy) {
         if (key in eslintrcConfig && typeof eslintrcConfig[key] !== "undefined") {
@@ -215,15 +204,17 @@ class FlatCompat {
 
     constructor({
         baseDirectory = process.cwd(),
-        resolvePluginsRelativeTo = baseDirectory
+        resolvePluginsRelativeTo = baseDirectory,
+        recommendedConfig,
+        allConfig
     } = {}) {
         this.baseDirectory = baseDirectory;
         this.resolvePluginsRelativeTo = resolvePluginsRelativeTo;
         this[cafactory] = new ConfigArrayFactory({
             cwd: baseDirectory,
             resolvePluginsRelativeTo,
-            getEslintAllConfig: () => ({ settings: { "eslint:all": true } }),
-            getEslintRecommendedConfig: () => ({ settings: { "eslint:recommended": true } })
+            getEslintAllConfig: () => allConfig,
+            getEslintRecommendedConfig: () => recommendedConfig
         });
     }
 

--- a/lib/flat-compat.js
+++ b/lib/flat-compat.js
@@ -213,8 +213,22 @@ class FlatCompat {
         this[cafactory] = new ConfigArrayFactory({
             cwd: baseDirectory,
             resolvePluginsRelativeTo,
-            getEslintAllConfig: () => allConfig,
-            getEslintRecommendedConfig: () => recommendedConfig
+            getEslintAllConfig: () => {
+
+                if (!allConfig) {
+                    throw new TypeError("Missing parameter 'allConfig' in FlatCompat constructor.");
+                }
+
+                return allConfig;
+            },
+            getEslintRecommendedConfig: () => {
+
+                if (!allConfig) {
+                    throw new TypeError("Missing parameter 'recommendedConfig' in FlatCompat constructor.");
+                }
+                
+                return recommendedConfig;
+            }
         });
     }
 

--- a/lib/flat-compat.js
+++ b/lib/flat-compat.js
@@ -223,10 +223,10 @@ class FlatCompat {
             },
             getEslintRecommendedConfig: () => {
 
-                if (!allConfig) {
+                if (!recommendedConfig) {
                     throw new TypeError("Missing parameter 'recommendedConfig' in FlatCompat constructor.");
                 }
-                
+
                 return recommendedConfig;
             }
         });

--- a/tests/lib/flat-compat.js
+++ b/tests/lib/flat-compat.js
@@ -366,6 +366,26 @@ describe("FlatCompat", () => {
                 });
             });
 
+            it("should throw an error when extending eslint:all without allConfig", () => {
+                const invalidCompat = new FlatCompat();
+
+                assert.throws(() => {
+                    invalidCompat.config({
+                        extends: "eslint:all"
+                    });
+                }, /Missing parameter 'allConfig'/gu);
+            });
+
+            it("should throw an error when extending eslint:recommended without recommendedConfig", () => {
+                const invalidCompat = new FlatCompat();
+
+                assert.throws(() => {
+                    invalidCompat.config({
+                        extends: "eslint:recommended"
+                    });
+                }, /Missing parameter 'recommendedConfig'/gu);
+            });
+
         });
 
         describe("overrides", () => {
@@ -907,6 +927,22 @@ describe("FlatCompat", () => {
                     foobar: "error"
                 }
             });
+        });
+
+        it("should throw an error when extending eslint:all without allConfig", () => {
+            const invalidCompat = new FlatCompat();
+
+            assert.throws(() => {
+                invalidCompat.extends("eslint:all");
+            }, /Missing parameter 'allConfig'/gu);
+        });
+
+        it("should throw an error when extending eslint:recommended without recommendedConfig", () => {
+            const invalidCompat = new FlatCompat();
+
+            assert.throws(() => {
+                invalidCompat.extends("eslint:recommended");
+            }, /Missing parameter 'recommendedConfig'/gu);
         });
 
     });

--- a/tests/lib/flat-compat.js
+++ b/tests/lib/flat-compat.js
@@ -945,6 +945,16 @@ describe("FlatCompat", () => {
             }, /Missing parameter 'recommendedConfig'/gu);
         });
 
+        it("should throw an error when extending eslint:recommended without recommendedConfig but with allConfig", () => {
+            const invalidCompat = new FlatCompat({
+                allConfig: {}
+            });
+
+            assert.throws(() => {
+                invalidCompat.extends("eslint:recommended");
+            }, /Missing parameter 'recommendedConfig'/gu);
+        });
+
     });
 
 

--- a/tests/lib/flat-compat.js
+++ b/tests/lib/flat-compat.js
@@ -62,7 +62,9 @@ describe("FlatCompat", () => {
 
         beforeEach(() => {
             compat = new FlatCompat({
-                baseDirectory
+                baseDirectory,
+                recommendedConfig: { settings: { "eslint:recommended": true } },
+                allConfig: { settings: { "eslint:all": true } }
             });
         });
 
@@ -239,7 +241,7 @@ describe("FlatCompat", () => {
                 });
             });
 
-            it("should translate extends eslint:all into a string", () => {
+            it("should translate extends eslint:all into settings", () => {
                 const result = compat.config({
                     extends: "eslint:all",
                     rules: {
@@ -248,7 +250,7 @@ describe("FlatCompat", () => {
                 });
 
                 assert.strictEqual(result.length, 2);
-                assert.deepStrictEqual(result[0], "eslint:all");
+                assert.isTrue(result[0].settings["eslint:all"]);
                 assert.deepStrictEqual(result[1], {
                     rules: {
                         foo: "warn"
@@ -256,7 +258,7 @@ describe("FlatCompat", () => {
                 });
             });
 
-            it("should translate extends [eslint:all] into a string", () => {
+            it("should translate extends [eslint:all] into settings", () => {
                 const result = compat.config({
                     extends: ["eslint:all"],
                     rules: {
@@ -265,7 +267,7 @@ describe("FlatCompat", () => {
                 });
 
                 assert.strictEqual(result.length, 2);
-                assert.deepStrictEqual(result[0], "eslint:all");
+                assert.isTrue(result[0].settings["eslint:all"]);
                 assert.deepStrictEqual(result[1], {
                     rules: {
                         foo: "warn"
@@ -273,7 +275,7 @@ describe("FlatCompat", () => {
                 });
             });
 
-            it("should translate extends eslint:recommended into a string", () => {
+            it("should translate extends eslint:recommended into settings", () => {
                 const result = compat.config({
                     extends: "eslint:recommended",
                     rules: {
@@ -282,7 +284,7 @@ describe("FlatCompat", () => {
                 });
 
                 assert.strictEqual(result.length, 2);
-                assert.deepStrictEqual(result[0], "eslint:recommended");
+                assert.isTrue(result[0].settings["eslint:recommended"]);
                 assert.deepStrictEqual(result[1], {
                     rules: {
                         foo: "warn"
@@ -290,7 +292,7 @@ describe("FlatCompat", () => {
                 });
             });
 
-            it("should translate extends [eslint:recommended] into a string", () => {
+            it("should translate extends [eslint:recommended] into settings", () => {
                 const result = compat.config({
                     extends: ["eslint:recommended"],
                     rules: {
@@ -299,7 +301,7 @@ describe("FlatCompat", () => {
                 });
 
                 assert.strictEqual(result.length, 2);
-                assert.deepStrictEqual(result[0], "eslint:recommended");
+                assert.isTrue(result[0].settings["eslint:recommended"]);
                 assert.deepStrictEqual(result[1], {
                     rules: {
                         foo: "warn"
@@ -346,7 +348,7 @@ describe("FlatCompat", () => {
                         }
                     }
                 });
-                assert.deepStrictEqual(result[1], "eslint:all");
+                assert.isTrue(result[1].settings["eslint:all"]);
                 assert.deepStrictEqual(result[2], {
                     languageOptions: {
                         globals: {
@@ -850,7 +852,9 @@ describe("FlatCompat", () => {
 
         beforeEach(() => {
             compat = new FlatCompat({
-                baseDirectory: getFixturePath("config")
+                baseDirectory: getFixturePath("config"),
+                recommendedConfig: { settings: { "eslint:recommended": true } },
+                allConfig: { settings: { "eslint:all": true } }
             });
         });
 
@@ -867,18 +871,18 @@ describe("FlatCompat", () => {
             });
         });
 
-        it("should translate extends eslint:all into a string", () => {
+        it("should translate extends eslint:all into settings", () => {
             const result = compat.extends("eslint:all");
 
             assert.strictEqual(result.length, 1);
-            assert.deepStrictEqual(result[0], "eslint:all");
+            assert.isTrue(result[0].settings["eslint:all"]);
         });
 
-        it("should translate extends eslint:recommended into a string", () => {
+        it("should translate extends eslint:recommended into settings", () => {
             const result = compat.extends("eslint:recommended");
 
             assert.strictEqual(result.length, 1);
-            assert.deepStrictEqual(result[0], "eslint:recommended");
+            assert.isTrue(result[0].settings["eslint:recommended"]);
         });
 
         it("should translate extends array with multiple configs into config objects", () => {
@@ -892,7 +896,7 @@ describe("FlatCompat", () => {
                     }
                 }
             });
-            assert.deepStrictEqual(result[1], "eslint:all");
+            assert.isTrue(result[1].settings["eslint:all"]);
             assert.deepStrictEqual(result[2], {
                 languageOptions: {
                     globals: {


### PR DESCRIPTION
Switches `FlatCompat` to require configs for `eslint:recommended` and `eslint:all` to be passed in as parameters.

* Adds `allConfig` and `recommendedConfig` as parameters to `FlatCompat` constructor
* Throws an error if `eslint:recommended` or `eslint:all` are extended without defining `recommendedConfig` or `allConfig`, respectively.

Refs eslint/eslint#16844

Should be released before eslint/eslint#16844 is released.