### PR TITLE
feat: add `es2023` and `es2024` environments

### DIFF
--- a/conf/environments.js
+++ b/conf/environments.js
@@ -114,6 +114,18 @@ export default new Map(Object.entries({
             ecmaVersion: 13
         }
     },
+    es2023: {
+        globals: { ...newGlobals2015, ...newGlobals2017, ...newGlobals2020, ...newGlobals2021 },
+        parserOptions: {
+            ecmaVersion: 14
+        }
+    },
+    es2024: {
+        globals: { ...newGlobals2015, ...newGlobals2017, ...newGlobals2020, ...newGlobals2021 },
+        parserOptions: {
+            ecmaVersion: 15
+        }
+    },
 
     // Platforms
     browser: {


### PR DESCRIPTION
Refs https://github.com/eslint/eslint/issues/17298, https://github.com/eslint/espree/pull/575

Adds `es2023` and `es2024` environments.