### PR TITLE
fix: Ensure environments in overrides respect files patterns

### DIFF
--- a/lib/flat-compat.js
+++ b/lib/flat-compat.js
@@ -168,14 +168,20 @@ function translateESLintRC(eslintrcConfig, {
                 if (environments.has(envName)) {
 
                     // built-in environments should be defined first
-                    configs.unshift(...translateESLintRC(environments.get(envName), {
+                    configs.unshift(...translateESLintRC({
+                        criteria: eslintrcConfig.criteria,
+                        ...environments.get(envName)
+                    }, {
                         resolveConfigRelativeTo,
                         resolvePluginsRelativeTo
                     }));
                 } else if (pluginEnvironments.has(envName)) {
 
                     // if the environment comes from a plugin, it should come after the plugin config
-                    configs.push(...translateESLintRC(pluginEnvironments.get(envName), {
+                    configs.push(...translateESLintRC({
+                        criteria: eslintrcConfig.criteria,
+                        ...pluginEnvironments.get(envName)
+                    }, {
                         resolveConfigRelativeTo,
                         resolvePluginsRelativeTo
                     }));

--- a/tests/lib/flat-compat.js
+++ b/tests/lib/flat-compat.js
@@ -215,6 +215,92 @@ describe("FlatCompat", () => {
                 });
             });
 
+            it("should translate builtin env with files", () => {
+                const result = compat.config({
+                    rules: {
+                        foo: "error"
+                    },
+                    overrides: [
+                        {
+                            files: "*.jsx",
+                            env: {
+                                amd: true
+                            }
+                        }
+                    ]
+                });
+
+                assert.strictEqual(result.length, 3);
+
+                assert.deepStrictEqual(result[0], {
+                    rules: {
+                        foo: "error"
+                    }
+                });
+
+                assert.deepStrictEqual(result[1].languageOptions, {
+                    ...environments.get("amd")
+                });
+                assert.typeOf(result[1].files[0], "function");
+                assert.isTrue(result[1].files[0]("/usr/eslint/foo.jsx"));
+                assert.isFalse(result[1].files[0]("/usr/eslint/foo.js"));
+
+                assert.typeOf(result[2].files[0], "function");
+                assert.isTrue(result[2].files[0]("/usr/eslint/foo.jsx"));
+                assert.isFalse(result[2].files[0]("/usr/eslint/foo.js"));
+            });
+
+            it("should translate plugin env with files", () => {
+                const result = compat.config({
+                    rules: {
+                        foo: "error"
+                    },
+                    overrides: [
+                        {
+                            files: "*.jsx",
+                            plugins: ["fixture3"],
+                            env: {
+                                "fixture3/a": true,
+                                "fixture3/b": true
+                            }
+                        }
+                    ]
+                });
+
+                assert.strictEqual(result.length, 4);
+
+                assert.deepStrictEqual(result[0], {
+                    rules: {
+                        foo: "error"
+                    }
+                });
+
+                assert.deepStrictEqual(result[1].languageOptions, {
+                    globals: {
+                        foo: true
+                    }
+                });
+                assert.typeOf(result[1].files[0], "function");
+                assert.isTrue(result[1].files[0]("/usr/eslint/foo.jsx"));
+                assert.isFalse(result[1].files[0]("/usr/eslint/foo.js"));
+
+                assert.deepStrictEqual(result[2].languageOptions, {
+                    globals: {
+                        bar: false
+                    }
+                });
+                assert.typeOf(result[2].files[0], "function");
+                assert.isTrue(result[2].files[0]("/usr/eslint/foo.jsx"));
+                assert.isFalse(result[2].files[0]("/usr/eslint/foo.js"));
+
+                assert.deepStrictEqual(result[3].plugins, {
+                    fixture3: pluginFixture3
+                });
+                assert.typeOf(result[3].files[0], "function");
+                assert.isTrue(result[3].files[0]("/usr/eslint/foo.jsx"));
+                assert.isFalse(result[3].files[0]("/usr/eslint/foo.js"));
+            });
+
         });
 
         describe("extends", () => {
@@ -956,7 +1042,6 @@ describe("FlatCompat", () => {
         });
 
     });
-
 
     describe("plugins()", () => {
 


### PR DESCRIPTION
Prior to this patch, if there was an environment enabled inside of an override config then it was translated into a universal config and always applied to every file that was linted. This change ensures that the `files` pattern is kept when environments are used inside of overrides, so those environments only apply when there is a match.


Fixes #125