### PR TITLE
Ignore files in .gitignore and .eslintignore by default

### DIFF
--- a/lib/config-array-factory.js
+++ b/lib/config-array-factory.js
@@ -598,13 +598,23 @@ class ConfigArrayFactory {
      */
     loadDefaultESLintIgnore() {
         const slots = internalSlotsMap.get(this);
+        const gitIgnorePath = path.resolve(slots.cwd, ".gitignore");
         const eslintIgnorePath = path.resolve(slots.cwd, ".eslintignore");
         const packageJsonPath = path.resolve(slots.cwd, "package.json");
 
-        if (fs.existsSync(eslintIgnorePath)) {
+        const gitIgnoreExists = fs.existsSync(gitIgnorePath);
+        const eslintIgnoreExists = fs.existsSync(eslintIgnorePath);
+
+        if (gitIgnoreExists && eslintIgnoreExists) {
+            return new ConfigArray(
+                ...this.loadESLintIgnore(gitIgnorePath),
+                ...this.loadESLintIgnore(eslintIgnorePath),
+            );
+        } else if (gitIgnoreExists) {
+            return this.loadESLintIgnore(gitIgnorePath);
+        } else if (eslintIgnoreExists) {
             return this.loadESLintIgnore(eslintIgnorePath);
-        }
-        if (fs.existsSync(packageJsonPath)) {
+        } else if (fs.existsSync(packageJsonPath)) {
             const data = loadJSONConfigFile(packageJsonPath);
 
             if (Object.hasOwnProperty.call(data, "eslintIgnore")) {

--- a/tests/lib/cascading-config-array-factory.js
+++ b/tests/lib/cascading-config-array-factory.js
@@ -37,9 +37,8 @@ const {
 /** @typedef {ReturnType<CascadingConfigArrayFactory["getConfigArrayForFile"]>} ConfigArray */
 
 const cwdIgnorePatterns = new ConfigArrayFactory()
-    .loadDefaultESLintIgnore()[0]
-    .ignorePattern
-    .patterns;
+    .loadDefaultESLintIgnore().flatMap(c => c.ignorePattern.patterns);
+
 
 const eslintAllPath = path.resolve(dirname, "../fixtures/eslint-all.cjs");
 const eslintRecommendedPath = path.resolve(dirname, "../fixtures/eslint-recommended.cjs");


### PR DESCRIPTION
Prettier scans .gitignore and .eslintignore by default. See https://prettier.io/docs/en/cli#--ignore-path.