### PR TITLE
fix: Use original plugin from disk in FlatCompat

### DIFF
--- a/lib/config-array-factory.js
+++ b/lib/config-array-factory.js
@@ -1053,6 +1053,7 @@ class ConfigArrayFactory {
         if (plugin) {
             return new ConfigDependency({
                 definition: normalizePlugin(plugin),
+                original: plugin,
                 filePath: "", // It's unknown where the plugin came from.
                 id,
                 importerName: ctx.name,
@@ -1089,6 +1090,7 @@ class ConfigArrayFactory {
 
                 return new ConfigDependency({
                     definition: normalizePlugin(pluginDefinition),
+                    original: pluginDefinition,
                     filePath,
                     id,
                     importerName: ctx.name,

--- a/lib/config-array/config-dependency.js
+++ b/lib/config-array/config-dependency.js
@@ -28,6 +28,7 @@ class ConfigDependency {
      * Initialize this instance.
      * @param {Object} data The dependency data.
      * @param {T} [data.definition] The dependency if the loading succeeded.
+     * @param {T} [data.original] The original, non-normalized dependency if the loading succeeded.
      * @param {Error} [data.error] The error object if the loading failed.
      * @param {string} [data.filePath] The actual path to the dependency if the loading succeeded.
      * @param {string} data.id The ID of this dependency.
@@ -36,6 +37,7 @@ class ConfigDependency {
      */
     constructor({
         definition = null,
+        original = null,
         error = null,
         filePath = null,
         id,
@@ -48,6 +50,12 @@ class ConfigDependency {
          * @type {T|null}
          */
         this.definition = definition;
+
+        /**
+         * The original dependency as loaded directly from disk if the loading succeeded.
+         * @type {T|null}
+         */
+        this.original = original;
 
         /**
          * The error object if the loading failed.

--- a/lib/flat-compat.js
+++ b/lib/flat-compat.js
@@ -132,7 +132,7 @@ function translateESLintRC(eslintrcConfig, {
             debug(`Translating plugin: ${pluginName}`);
             debug(`Resolving plugin '${pluginName} relative to ${resolvePluginsRelativeTo}`);
 
-            const { definition: plugin, error } = eslintrcConfig.plugins[pluginName];
+            const { original: plugin, error } = eslintrcConfig.plugins[pluginName];
 
             if (error) {
                 throw error;

--- a/tests/lib/config-array-factory.js
+++ b/tests/lib/config-array-factory.js
@@ -631,6 +631,10 @@ describe("ConfigArrayFactory", () => {
                 it("should have the path to the package at 'plugins[id].filePath' property.", () => {
                     assert.strictEqual(element.plugins.xxx.filePath, path.join(getPath(), "node_modules/custom-eslint-plugin-xxx/index.js"));
                 });
+
+                it("should have the original definition equal to the origina plugin object", () => {
+                    assert.strictEqual(element.plugins.xxx.original, require(path.join(getPath(), "node_modules/custom-eslint-plugin-xxx/index.js")));
+                });
             });
 
             describe("if 'extends' property was 'foo', the returned value", () => {

--- a/tests/lib/config-array/config-dependency.js
+++ b/tests/lib/config-array/config-dependency.js
@@ -68,7 +68,8 @@ describe("ConfigDependency", () => {
                     filePath: "filePath?",
                     id: "id?",
                     importerName: "importerName?",
-                    importerPath: "importerPath?"
+                    importerPath: "importerPath?",
+                    original: null
                 }
             );
         });
@@ -105,6 +106,7 @@ describe("ConfigDependency", () => {
             // Make expected output; no `definition` property.
             output = "";
             localConsole.log({
+                original: null,
                 error,
                 filePath: "filePath?",
                 id: "id?",

--- a/tests/lib/flat-compat.js
+++ b/tests/lib/flat-compat.js
@@ -12,8 +12,10 @@ import { fileURLToPath, pathToFileURL } from "url";
 import { assert } from "chai";
 import { FlatCompat } from "../../lib/index.js";
 import environments from "../../conf/environments.js";
+import { createRequire } from "module";
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
 
 //-----------------------------------------------------------------------------
 // Helpers
@@ -56,9 +58,9 @@ describe("FlatCompat", () => {
 
         let compat;
         const baseDirectory = getFixturePath("config");
-        const pluginFixture1 = normalizePlugin((await import(pathToFileURL(path.join(baseDirectory, "node_modules/eslint-plugin-fixture1.js")))).default);
-        const pluginFixture2 = normalizePlugin((await import(pathToFileURL(path.join(baseDirectory, "node_modules/eslint-plugin-fixture2.js")))).default);
-        const pluginFixture3 = normalizePlugin((await import(pathToFileURL(path.join(baseDirectory, "node_modules/eslint-plugin-fixture3.js")))).default);
+        const pluginFixture1 = (await import(pathToFileURL(path.join(baseDirectory, "node_modules/eslint-plugin-fixture1.js")))).default;
+        const pluginFixture2 = (await import(pathToFileURL(path.join(baseDirectory, "node_modules/eslint-plugin-fixture2.js")))).default;
+        const pluginFixture3 = (await import(pathToFileURL(path.join(baseDirectory, "node_modules/eslint-plugin-fixture3.js")))).default;
 
         beforeEach(() => {
             compat = new FlatCompat({
@@ -1059,13 +1061,7 @@ describe("FlatCompat", () => {
             assert.strictEqual(result.length, 1);
             assert.deepStrictEqual(result[0], {
                 plugins: {
-                    fixture1: {
-                        configs: {},
-                        rules: {},
-                        environments: {},
-                        processors: {},
-                        ...(await import(pathToFileURL(path.join(compat.baseDirectory, "node_modules/eslint-plugin-fixture1.js")))).default
-                    }
+                    fixture1: (await import(pathToFileURL(path.join(compat.baseDirectory, "node_modules/eslint-plugin-fixture1.js")))).default
                 }
             });
         });
@@ -1087,13 +1083,7 @@ describe("FlatCompat", () => {
             });
             assert.deepStrictEqual(result[1], {
                 plugins: {
-                    fixture2: {
-                        configs: {},
-                        rules: {},
-                        environments: {},
-                        processors: {},
-                        ...plugin
-                    }
+                    fixture2: plugin
                 }
             });
         });
@@ -1109,22 +1099,17 @@ describe("FlatCompat", () => {
             });
             assert.deepStrictEqual(result[1], {
                 plugins: {
-                    fixture1: {
-                        configs: {},
-                        rules: {},
-                        environments: {},
-                        processors: {},
-                        ...(await import(pathToFileURL(path.join(compat.baseDirectory, "node_modules/eslint-plugin-fixture1.js")))).default
-                    },
-                    fixture2: {
-                        configs: {},
-                        rules: {},
-                        environments: {},
-                        processors: {},
-                        ...plugin
-                    }
+                    fixture1: (await import(pathToFileURL(path.join(compat.baseDirectory, "node_modules/eslint-plugin-fixture1.js")))).default,
+                    fixture2: plugin
                 }
             });
+        });
+
+        it("should use the same plugin instance as require()", async () => {
+            const result = compat.config({ plugins: ["fixture2"]});
+            const plugin = require(path.join(compat.baseDirectory, "node_modules/eslint-plugin-fixture2.js"));
+
+            assert.strictEqual(result[1].plugins.fixture2, plugin);
         });
 
     });


### PR DESCRIPTION
This switches `FlatCompat` to use the original (unnormalized) version of the plugin that was loaded from disk rather than the normalized version. This ensures that we'll avoid plugin redefinition errors when folks are using both `FlatCompat` and their own imports.

Fixes #135