### PR TITLE
chore: upgrade espree@10.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "dependencies": {
     "ajv": "^6.12.4",
     "debug": "^4.3.2",
-    "espree": "^9.6.0",
+    "espree": "^10.0.1",
     "globals": "^13.19.0",
     "ignore": "^5.2.0",
     "import-fresh": "^3.2.1",


### PR DESCRIPTION
Updates espree dependency to just-released v10.0.1.