### PR TITLE
ci: run tests in Node.js 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [21.x, 20.x, 18.x, "18.18.0"]
+        node: [22.x, 21.x, 20.x, 18.x, "18.18.0"]
         include:
         - os: windows-latest
           node: "lts/*"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,9 +29,9 @@ jobs:
               { "type": "refactor", "section": "Chores", "hidden": false },
               { "type": "test", "section": "Chores", "hidden": false }
             ]
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: ${{ steps.release.outputs.release_created }}
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: lts/*
           registry-url: https://registry.npmjs.org


### PR DESCRIPTION
[Node.js 22](https://github.com/nodejs/node/releases/tag/v22.0.0) has been released. This PR updates the GitHub Actions CI workflow to run tests also in Node.js 22.

It also bumps [actions/checkout](https://github.com/actions/checkout) and [actions/setup-node](https://github.com/actions/setup-node) used in the release-please workflow to the latest versions. This ensures that the actions will be updated to work with upcoming version of Node.js.