### PR TITLE
chore: update dependency shelljs to ^0.8.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "fs-teardown": "^0.1.3",
     "mocha": "^9.0.3",
     "rollup": "^2.70.1",
-    "shelljs": "^0.8.4",
+    "shelljs": "^0.8.5",
     "sinon": "^11.1.2",
     "temp-dir": "^2.0.0"
   },


### PR DESCRIPTION
Versions of shelljs prior to v0.8.5 are affected by a high rated security vulnerability. It's unlikely that anyone working with this repo has one of those older versions installed, but they are not automatically updated as long as they match the version range in package.json. This PR updates package.json to ensure that only shelljs ^0.8.5 is used.

NVD advisory: https://nvd.nist.gov/vuln/detail/CVE-2022-0144