### PR TITLE
feat: Expose loadConfigFile() function

### DIFF
--- a/lib/config-array-factory.js
+++ b/lib/config-array-factory.js
@@ -1148,4 +1148,8 @@ class ConfigArrayFactory {
     }
 }
 
-export { ConfigArrayFactory, createContext };
+export {
+    ConfigArrayFactory,
+    createContext,
+    loadConfigFile
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,8 @@
 
 import {
     ConfigArrayFactory,
-    createContext as createConfigArrayFactoryContext
+    createContext as createConfigArrayFactoryContext,
+    loadConfigFile
 } from "./config-array-factory.js";
 
 import { CascadingConfigArrayFactory } from "./cascading-config-array-factory.js";
@@ -39,6 +40,7 @@ const Legacy = {
     OverrideTester,
     getUsedExtractedConfigs,
     environments,
+    loadConfigFile,
 
     // shared
     ConfigOps,


### PR DESCRIPTION
This PR exposes the `loadConfigFile()` function publicly. This is need to aid in the creation of a config migration tool.