### PR TITLE
refactor: upgrade minimatch version

### DIFF
--- a/lib/config-array/override-tester.js
+++ b/lib/config-array/override-tester.js
@@ -20,9 +20,7 @@
 import assert from "assert";
 import path from "path";
 import util from "util";
-import minimatch from "minimatch";
-
-const { Minimatch } = minimatch;
+import { Minimatch } from "minimatch";
 
 const minimatchOpts = { dot: true, matchBase: true };
 

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "ignore": "^5.2.0",
     "import-fresh": "^3.2.1",
     "js-yaml": "^4.1.0",
-    "minimatch": "^3.1.2",
+    "minimatch": "^9.0.5",
     "strip-json-comments": "^3.1.1"
   },
   "engines": {


### PR DESCRIPTION
hi there

I noticed that this project uses a really old version of `minimatch` library (v3 where the latest is v10). While it is impossible to upgrade to the latest one (since the author [dropped](https://github.com/isaacs/minimatch/commit/632e0da294b644ce2b537df4d64d4316fd84e0f1) support for Node18, that is listed as a supported engine of this repo), we can still upgrade to the v9 since it supports Node18. The only breaking change I faced is a removal of default export that is easily fixable and all the tests were green again