### PR TITLE
ci: run tests in Node.js 23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [22.x, 21.x, 20.x, 18.x, "18.18.0"]
+        node: [23.x, 22.x, 21.x, 20.x, 18.x, "18.18.0"]
         include:
         - os: windows-latest
           node: "lts/*"


### PR DESCRIPTION
This PR updates the GitHub Actions CI workflow to run tests also in Node.js 23.

refs eslint/eslint#19031