### PR TITLE
feat: support private package

### DIFF
--- a/lib/shared/naming.js
+++ b/lib/shared/naming.js
@@ -23,6 +23,13 @@ function normalizePackageName(name, prefix) {
         normalizedName = normalizedName.replace(/\\/gu, "/");
     }
 
+    /**
+     * Support defining a private package starting with the # symbol in the imports of package.json
+     */
+    if (normalizedName.charAt(0) === "#") {
+        return normalizedName;
+    }
+
     if (normalizedName.charAt(0) === "@") {
 
         /**


### PR DESCRIPTION
Support defining a private package starting with the # symbol in the package.json

`
// package.json
"imports": {
    "#eslint-plugin-xxx": "./eslint-plugin/xxx.js"
}


// .eslintrc.js
plugins: ['#eslint-plugin-maipu']
`

