### PR TITLE
docs: update readme to include bun install

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ This repository contains the legacy ESLintRC configuration file format for ESLin
 
 You can install the package as follows:
 
-```
+```bash
 npm install @eslint/eslintrc --save-dev
-
 # or
-
 yarn add @eslint/eslintrc -D
+# or
+bun add @eslint/eslintrc -D
 ```
 
 ## Usage (ESM)

--- a/README.md
+++ b/README.md
@@ -8,12 +8,14 @@ This repository contains the legacy ESLintRC configuration file format for ESLin
 
 You can install the package as follows:
 
-```bash
-npm install @eslint/eslintrc --save-dev
+```shell
+npm install @eslint/eslintrc -D
 # or
 yarn add @eslint/eslintrc -D
 # or
-bun add @eslint/eslintrc -D
+pnpm install @eslint/eslintrc -D
+# or
+bun install @eslint/eslintrc -D
 ```
 
 ## Usage (ESM)


### PR DESCRIPTION
Updates the installation instructions to include bun, also changes the syntax highlighting to bash so it looks prettier.