### PR TITLE
fix: correct `types` field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "The legacy ESLintRC config file format for ESLint",
   "type": "module",
   "main": "./dist/eslintrc.cjs",
-  "types": "./dist/eslintrc.d.ts",
+  "types": "./dist/eslintrc.d.cts",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,3 +1,21 @@
+/** List of modules not included in the bundle. */
+const external = [
+    "node:assert",
+    "node:fs",
+    "node:module",
+    "node:os",
+    "node:path",
+    "node:url",
+    "node:util",
+    "ajv",
+    "debug",
+    "globals",
+    "ignore",
+    "import-fresh",
+    "minimatch",
+    "strip-json-comments"
+];
+
 /**
  * Custom Rollup plugin for `import.meta.url` transformation to commonjs.
  * The default transformation ('file:' + __filename) does not check characters in __filename,
@@ -20,11 +38,7 @@ function importMetaURLPlugin() {
 export default [
     {
         input: "./lib/index.js",
-        external: [
-            "module", "util", "os", "path", "debug", "fs", "import-fresh",
-            "strip-json-comments", "assert", "ignore", "minimatch", "url", "ajv",
-            "globals"
-        ],
+        external,
         treeshake: false,
         output: {
             format: "cjs",
@@ -36,11 +50,7 @@ export default [
     },
     {
         input: "./lib/index-universal.js",
-        external: [
-            "module", "util", "os", "path", "debug", "fs", "import-fresh",
-            "strip-json-comments", "assert", "ignore", "minimatch", "url", "ajv",
-            "globals"
-        ],
+        external,
         treeshake: false,
         output: {
             format: "cjs",


### PR DESCRIPTION
This PR fixes an incorrect path in the `types` field in `packages.json`, originally reported in #183. I think the incorrect `types` field would only cause a problem on old versions of TypeScript (<4.5) that don't honor the `exports` field, but since the field is there it should be corrected.

[**Repro**](https://stackblitz.com/edit/eslintrc-types-field-repro)

I also noticed that Rollup is issuing warnings during the build because of undeclared external modules that had recently the `node:` prefix added (see output below), and I updated the Rollup config to remove the warnings.

```text
$ npm run build    

> @eslint/eslintrc@3.3.0 build
> rollup -c && node -e "fs.copyFileSync('./lib/types/index.d.ts', './dist/eslintrc.d.cts')"


./lib/index.js → dist/eslintrc.cjs...
(!) Unresolved dependencies
https://rollupjs.org/guide/en/#warning-treating-module-as-external-dependency
node:fs (imported by lib/config-array-factory.js)
node:module (imported by lib/config-array-factory.js, lib/shared/relative-module-resolver.js)
node:path (imported by lib/config-array-factory.js, lib/cascading-config-array-factory.js, lib/config-array/ignore-pattern.js, lib/config-array/override-tester.js, lib/flat-compat.js, lib/shared/deprecation-warnings.js)
node:os (imported by lib/cascading-config-array-factory.js)
node:util (imported by lib/config-array/config-dependency.js, lib/config-array/override-tester.js, lib/shared/config-validator.js)
node:assert (imported by lib/config-array/ignore-pattern.js, lib/config-array/override-tester.js)
created dist/eslintrc.cjs in 64ms

./lib/index-universal.js → dist/eslintrc-universal.cjs...
(!) Unresolved dependencies
https://rollupjs.org/guide/en/#warning-treating-module-as-external-dependency
node:util (imported by lib/shared/config-validator.js)
node:path (imported by lib/shared/deprecation-warnings.js)
created dist/eslintrc-universal.cjs in 13ms
```

refs #183