### PR TITLE
fix: Remove name property from all and recommended configs

### DIFF
--- a/lib/flat-compat.js
+++ b/lib/flat-compat.js
@@ -229,9 +229,7 @@ class FlatCompat {
                 // remove name property if it exists
                 const config = { ...allConfig };
 
-                if ("name" in config) {
-                    delete config.name;
-                }
+                delete config.name;
 
                 return config;
             },
@@ -244,9 +242,7 @@ class FlatCompat {
                 // remove name property if it exists
                 const config = { ...recommendedConfig };
 
-                if ("name" in config) {
-                    delete config.name;
-                }
+                delete config.name;
 
                 return config;
             }

--- a/tests/lib/flat-compat.js
+++ b/tests/lib/flat-compat.js
@@ -1049,7 +1049,6 @@ describe("FlatCompat", () => {
             assert.strictEqual(recommendedResult.length, 1);
             assert.isTrue(recommendedResult[0].settings["eslint:recommended"]);
         });
-
     });
 
     describe("plugins()", () => {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

PR [#20015](https://github.com/eslint/eslint/pull/20015) adds a `name` property to `eslint:all` and `eslint:recommended`. However, this will cause issues because these configs are still used in eslintrc, which does not support a `name` property and will throw an error.

#### What changes did you make? (Give an overview)

I updated `FlatCompat` to strip the `name` property from these configs

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

No