### PR TITLE
chore: update espree to v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "dependencies": {
     "ajv": "^6.12.4",
     "debug": "^4.3.2",
-    "espree": "^10.0.1",
+    "espree": "^11.0.0",
     "globals": "^14.0.0",
     "ignore": "^5.2.0",
     "import-fresh": "^3.2.1",


### PR DESCRIPTION
#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

#### What is the purpose of this pull request?
Update espree to v11. Done mostly for applying transient dependency of eslint-visitor-keys v5.
