### PR TITLE
fix: execption when invalid config has circular references

### DIFF
--- a/lib/shared/config-validator.js
+++ b/lib/shared/config-validator.js
@@ -305,7 +305,7 @@ export default class ConfigValidator {
             if (error.keyword === "type") {
                 const formattedField = error.dataPath.slice(1);
                 const formattedExpectedType = Array.isArray(error.schema) ? error.schema.join("/") : error.schema;
-                const formattedValue = JSON.stringify(error.data);
+                const formattedValue = util.inspect(error.data);
 
                 return `Property "${formattedField}" is the wrong type (expected ${formattedExpectedType} but got \`${formattedValue}\`)`;
             }

--- a/tests/lib/shared/config-validator.js
+++ b/tests/lib/shared/config-validator.js
@@ -283,4 +283,32 @@ describe("ConfigValidator", () => {
         });
 
     });
+
+    describe("validateConfigSchema", () => {
+
+        it("should not throw a circular structure error when the invalid value is circular", () => {
+
+            // `plugins` expects an array; passing a circular object triggers a
+            // "type" schema error whose `error.data` is the circular object.
+            const circular = { name: "eslint-plugin-react" };
+
+            circular.self = circular;
+
+            const config = { plugins: circular };
+
+            nodeAssert.throws(
+                () => validator.validateConfigSchema(config, "test-config"),
+                error => {
+                    nodeAssert.doesNotMatch(
+                        error.message,
+                        /circular structure/u,
+                        "Expected a config validation error, not a JSON circular structure error"
+                    );
+                    nodeAssert.match(error.message, /ESLint configuration in test-config is invalid/u);
+                    return true;
+                }
+            );
+        });
+
+    });
 });


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting. (used AI to generate the unit test)

#### What is the purpose of this pull request?

This PR fixes the exception from circular data when handling invalid config error

#### What changes did you make? (Give an overview)

replaced: `JSON.stringify` with `util.inspect`.

#### Related Issues

* https://github.com/eslint/eslint/issues/20237

#### Is there anything you'd like reviewers to focus on?
